### PR TITLE
Add assertions for role cleanup count

### DIFF
--- a/tests/test_role_manager_performance.py
+++ b/tests/test_role_manager_performance.py
@@ -118,6 +118,8 @@ async def test_role_manager_performance():
 
     # Verify expected behavior
     expected_roles = TEST_USER_COUNT * ROLES_PER_USER
+    assert removed_count == expected_roles
+    assert RoleQueries.delete_member_role.call_count == expected_roles
 
     # Verify the remove_roles calls
     for user_id, member in members.items():


### PR DESCRIPTION
## Summary
- improve performance test coverage for role cleanup

## Testing
- `./run_checks.sh` *(fails: pylint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685a93b0d8148328ade40754f1db9c46