### PR TITLE
Fix duplicate func import

### DIFF
--- a/datasources/queries.py
+++ b/datasources/queries.py
@@ -11,7 +11,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import and_, case, or_
-from sqlalchemy.sql.functions import func
 
 from datasources.models import (
     Activity,


### PR DESCRIPTION
## Summary
- remove redundant import of `func` from `sqlalchemy.sql.functions`

## Testing
- `python -m py_compile datasources/queries.py`
- `python - <<'EOF'
import importlib
module_name = 'datasources.queries'
try:
    importlib.import_module(module_name)
    print('imported successfully')
except Exception as e:
    print('import failed:', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685a93aa062883289eeb5a4fa2324c55